### PR TITLE
Change select event to ondblclick

### DIFF
--- a/QueryHelper/QueryHelper.js
+++ b/QueryHelper/QueryHelper.js
@@ -80,7 +80,7 @@
 	}
     function onLoad(response) {
 		var node = build(response.fields);
-		listenAll(node, "select", "onclick", function (evt) {
+		listenAll(node, "select", "ondblclick", function (evt) {
 			setActive(evt.currentTarget.value);
 		});
 		listenAll(node, "button.sql", "onclick", function (evt) {


### PR DESCRIPTION
Change to use ondblclick, instead of onclick, because in this way you can use this bookmarklet to see the values on a field before use it on a query. 

I've tested it on Firefox/Chrome only. 

Feel free to not use it if you want (I know that not everybody like double click). 