### PR TITLE
Replace Installation Instruction links in README.MD Files

### DIFF
--- a/DomainDataCounter/README.md
+++ b/DomainDataCounter/README.md
@@ -1,4 +1,4 @@
-# Domain Data Counter (ESRI REST Diagnostics) 
+# Domain Data Counter (ESRI REST Diagnostics)
 
 Bookmarklet to test ArcGIS REST Service fields with domains, counting the number of features with each domain value assigned to a field.
 
@@ -10,7 +10,7 @@ This bookmarklet scans an ArcGIS Server MapService layer for fields that have do
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page... 
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page... 
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".
@@ -33,7 +33,7 @@ The bookmarklets requests field properties for the layer and finds fields with d
 ## Notes
 
 - Currently untested on Safari. Please give me feedback if you try it.
-- Not tested on mobile/tablet browsers, since I'm not sure how bookmarklets work with those. 
+- Not tested on mobile/tablet browsers, since I'm not sure how bookmarklets work with those.
 
 ## Contributing
 

--- a/FieldTester/README.md
+++ b/FieldTester/README.md
@@ -1,16 +1,16 @@
-# Field Tester (ESRI REST Diagnostics) 
+# Field Tester (ESRI REST Diagnostics)
 
 Bookmarklets to test for field values populated by data.
 
 ## Features
 
-The bookmarklets count the number of features with values and return server response times for each field within an ArcGIS Server Map Service or Feature Service layer. The first tests for non-null data, while the second also checks for empty strings. You can use these bookmarklets to test data integrity and of each field, and roughly expected return times for queries. 
+The bookmarklets count the number of features with values and return server response times for each field within an ArcGIS Server Map Service or Feature Service layer. The first tests for non-null data, while the second also checks for empty strings. You can use these bookmarklets to test data integrity and of each field, and roughly expected return times for queries.
 
 ## Instructions
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page... 
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page... 
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".
@@ -33,7 +33,7 @@ The bookmarklets systematically queries for the count of each field value that i
 ## Notes
 
 - Currently untested on Safari. Please give me feedback if you try it.
-- Not tested on mobile/tablet browsers, since I'm not sure how bookmarklets work with those. 
+- Not tested on mobile/tablet browsers, since I'm not sure how bookmarklets work with those.
 
 ## Contributing
 

--- a/MapLayerCount/README.md
+++ b/MapLayerCount/README.md
@@ -1,4 +1,4 @@
-# Layer Feature Counter (ESRI REST Diagnostics) 
+# Layer Feature Counter (ESRI REST Diagnostics)
 
 A bookmarklet to get feature result counts from layers in a map service.
 
@@ -10,7 +10,7 @@ The bookmarklet queries each layer in the map service, getting a count of non-nu
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page... 
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page... 
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".
@@ -33,7 +33,7 @@ The tool adds lists after the links to each layer, listing the number of results
 ## Notes
 
 - Currently untested on Safari. Please give me feedback if you try it.
-- Not tested on mobile/tablet browsers, since I'm not sure how bookmarklets work with those. 
+- Not tested on mobile/tablet browsers, since I'm not sure how bookmarklets work with those.
 
 ## Contributing
 

--- a/MapLayerData/README.md
+++ b/MapLayerData/README.md
@@ -23,7 +23,7 @@ Data that the Layer Property Extractor provides includes.
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page... 
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page... 
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".

--- a/MapServiceData/README.md
+++ b/MapServiceData/README.md
@@ -6,7 +6,7 @@ A JavaScript bookmarklet for viewing all relevant map service data at a folder l
 
 This bookmarklet examines each map service whose link you can see, and lists data about each map service without having to navigate to it.
 
-Map Service data displayed includes 
+Map Service data displayed includes
 
 - Descriptions
 - Service Descriptions
@@ -27,7 +27,7 @@ Map Service data displayed includes
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page... 
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page...
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".

--- a/MapViewer/README.md
+++ b/MapViewer/README.md
@@ -10,7 +10,7 @@ This bookmarklet loads an ArcGIS JavaScript API based map on the REST Service pa
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page... 
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page...
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".

--- a/PrintTaskMadeEasy/README.md
+++ b/PrintTaskMadeEasy/README.md
@@ -10,7 +10,7 @@ This bookmarklet modifies the form for submitting an *Export Web Map Task*. It r
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page...
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page...
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".

--- a/QueryHelper/README.md
+++ b/QueryHelper/README.md
@@ -1,4 +1,4 @@
-# "Select By Attributes" Query Helper (ESRI REST Diagnostics) 
+# "Select By Attributes" Query Helper (ESRI REST Diagnostics)
 
 On the ArcGIS Server REST Query page for a layer, this bookmarklet presents the fields and SQL keywords in a useful form on the side of the page.
 
@@ -10,7 +10,7 @@ The bookmarklet renders a control on the side of the page that lists field names
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page...
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page...
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".

--- a/QuickQueryHelpers/README.md
+++ b/QuickQueryHelpers/README.md
@@ -27,7 +27,7 @@ These bookmarklets supply simple default values for fields in the ArcGIS Server 
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page...
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page...
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".

--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ The bookmarklets provided add extra information to the ArcGIS Server REST endpoi
   - [Adding ArcGIS REST API compliant geometry json to queries, based on a map of the map service.](https://github.com/raykendo/ESRI_REST_Diagnostics/tree/master/GeometryHelper)
 
 More features will be made available on request.
-  
+
 ## Instructions
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page... 
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page... 
 
 - Chrome: drag the anchor link to your browser toolbar. ![Install to Chrome illustration](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/images/Install_Chrome.gif "Installing bookmarklets on Chrome")
 - Firefox: right-click on the link and select "Bookmark this link". ![Install to Firefox illustration](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/images/Install_Firefox.gif "Installing bookmarklets on Firefox")

--- a/RestSearch/README.md
+++ b/RestSearch/README.md
@@ -12,7 +12,7 @@ This bookmarklet searches through map service folders and names, field names and
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page... 
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page... 
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".

--- a/SpatialRefCompare/README.md
+++ b/SpatialRefCompare/README.md
@@ -10,7 +10,7 @@ This bookmarklet displays and color-codes the spatial references of each map ser
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page... 
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page... 
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".

--- a/TileTester/README.md
+++ b/TileTester/README.md
@@ -12,7 +12,7 @@ This bookmarklet examines the links to the first and last tile in each level of 
 
 ### Installation
 
-Installation on the browser is as simple as adding a bookmark. From the [bookmarklet.html](https://github.com/raykendo/ESRI_REST_Diagnostics/blob/master/bookmarklets.html) page...
+Installation on the browser is as simple as adding a bookmark. From the [ESRI Rest Diagnostics](http://raykendo.github.io/ESRI_REST_Diagnostics/) page...
 
 - Chrome: drag the anchor link to your browser toolbar.
 - Firefox: right-click on the link and select "Bookmark this link".


### PR DESCRIPTION
The links under "Installation Instructions" in all of the README files point to the code for the bookmarklets page rather than to the actual page.